### PR TITLE
Update app.tsx

### DIFF
--- a/src/pages/content/components/app.tsx
+++ b/src/pages/content/components/app.tsx
@@ -25,11 +25,25 @@ const getInfoFileUrl = (show: ArchiveShow) => {
   return `${baseURL}/${infoFile}`;
 };
 
-const getShowTitle = (show: ArchiveShow) => {
-  const identifier =
-    window.location.pathname.split("/details/")[1]?.split("/")[0] ||
-    show.metadata.date[0];
-  return prompt(`Custom folder title? Default ${identifier}`, identifier);
+const getFolderName = (show: ArchiveShow) => {
+  const date = show.metadata.date?.[0] ?? "";
+  const venue = show.metadata.venue?.[0] ?? "";
+  const source = show.metadata.source?.[0] ?? "";
+  const sourceType = source.split(" ")?.[0] ?? "";
+  const identifier = show.metadata.identifier?.[0] ?? "";
+
+  // Prefer full identifier, fall back to descriptive string
+  let folderName = identifier;
+
+  if (!folderName) {
+    folderName = date;
+    if (venue) folderName += ` - ${venue}`;
+    if (sourceType) folderName += ` (${sourceType})`;
+  }
+
+  folderName = folderName.slice(0, 255);
+
+  return prompt(`Custom folder title? Default ${folderName}`, folderName);
 };
 
 async function fetchWithRedirect(url: string) {
@@ -179,7 +193,7 @@ const DownloadButton: FC<{ show: ArchiveShow }> = ({ show }) => {
     setProgress(0);
     setSuccess(false);
 
-    const showTitle = getShowTitle(archiveShow);
+    const showTitle = getFolderName(archiveShow);
     if (!showTitle) {
       setLoading(false);
       return;

--- a/src/pages/content/components/app.tsx
+++ b/src/pages/content/components/app.tsx
@@ -26,10 +26,10 @@ const getInfoFileUrl = (show: ArchiveShow) => {
 };
 
 const getShowTitle = (show: ArchiveShow) => {
-  return prompt(
-    `Custom folder title? Default ${show.metadata.date[0]}`,
-    show.metadata.date[0]
-  );
+  const identifier =
+    window.location.pathname.split("/details/")[1]?.split("/")[0] ||
+    show.metadata.date[0];
+  return prompt(`Custom folder title? Default ${identifier}`, identifier);
 };
 
 async function fetchWithRedirect(url: string) {

--- a/src/pages/content/models/interfaces.ts
+++ b/src/pages/content/models/interfaces.ts
@@ -19,6 +19,12 @@ export interface ArchiveShow {
 
 export interface Metadata {
   date: string[];
+  identifier?: string[];
+  venue?: string[];
+  source?: string[];
+  coverage?: string[];
+  subject?: string[];
+  transferer?: string[];
 }
 
 export interface Track {


### PR DESCRIPTION
_Use Archive.org identifier as default folder name_

---
Hey Chris! This is actually my first ever PR so please bear with me if anything's not quite right!

Following up on the issue I opened (tested and working here). https://github.com/chrisbendel/grateful-grabber/issues/67
Falls back to the date if no [Archive.org](http://archive.org/) identifier is found so it's fully backward compatible.
Thanks so much for this awesome extension and for being welcoming to a first time contributor! 

I did my best to match the existing code style and variable conventions, dug into the xpi first to find the logic then tracked it back to the source, etc.

---

**Re: your metadata question**

I checked it out and the JSON the grabber already fetches has a lot to work with in the metadata object:
https://archive.org/details/gd1973-02-17.163792.sbd.fixed.miller.flac1648&output=json

metadata.date[0] → 1973-02-17
metadata.venue[0] → St. Paul Auditorium
metadata.coverage[0] → St. Paul, MN
metadata.subject[0] → Soundboard;Charlie Miller
metadata.source[0] → full signal chain starting with source type (e.g. SBD > Reel Master...)
metadata.transferer[0] → taper name and contact

So I think your date/source idea is totally doable, something like 1973-02-17 (SBD) by grabbing the first word of metadata.source[0]. Maybe?

Could even do 1973-02-17 - St. Paul Auditorium (SBD) if you wanted more context. 
Happy to take a crack at it sometime if you need an extra set of eyes.

---

Strangers helping strangers 🤙